### PR TITLE
update to use docker for ffq and trimmomatic

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,12 @@
 // Usage (run on SGE):
 // nextflow run nextflow/nextflow_pratice.nf -c nextflow.config -profile sge
 
+
+// habilita o uso de docker 
+
+docker.enabled = true
+docker.runOptions = '-u $(id -u):$(id -g)'
+
 profiles {
 
     // TODO: Include more specific queues from CENA (SGE Cluster - figsrv, neotera)

--- a/nextflow/nextflow_pratice.nf
+++ b/nextflow/nextflow_pratice.nf
@@ -3,6 +3,7 @@
 params.reads = "SRR1156953"
 
 process getReadFTP {
+    container 'andreatelatin/getreads:2.0'
     input:
     val sra_accession
 
@@ -27,6 +28,7 @@ process downloadReadFTP {
 }
 
 process runTrimmomatic {
+    container 'staphb/trimmomatic'
     input:
     path fastq_read_list
 
@@ -34,14 +36,14 @@ process runTrimmomatic {
     if(fastq_read_list.size() == 2)
         """
         echo Running Trimmomatic PE mode
-        java -jar /media/renato/SSD1TB/Software/Trimmomatic-0.39/trimmomatic-0.39.jar PE \
+        trimmomatic PE \
         -trimlog trimmomatic.log $fastq_read_list -baseout output \
         MINLEN:15
         """
     else if(fastq_read_list.size() == 1)
         """
         echo Running Trimmomatic SE mode
-        java -jar /media/renato/SSD1TB/Software/Trimmomatic-0.39/trimmomatic-0.39.jar SE \
+        trimmomatic SE \
         -trimlog trimmomatic.log $fastq_read_list output.fastq.gz \
         MINLEN:15
         """


### PR DESCRIPTION
Galera, 

Pelo que vi no treinamento do Nextflow, tem muitissima coisa para fazer e melhorar o nosso pipeline. Eu só adicionei o uso de docker para assim fazer ele reproduzivel mesmo, porque meus primeiros erros foi com a ferramenta que não estava instalada (ffq) e que não estava na localização certa (trimmomatic). Então adicionei no nextflow.config duas linhas para habilitar o uso de docker, sem precisar colocar na linha de comando (fica por default) e adicionei no nextflow_practice.nf nos processos getReadFTP e runTrimmomatic os containers de docker, assim o usuário não tem que se preocupar pelas ferramentas. Mas é claro que tem que ter instalado o docker na maquina. 

Da minha parte que era ver como se cria o gráfico do workflow, é muito simples, é só colocar na linha de comando -with-dag flowchart.png. Porém tem que ter instalado previamente a ferramenta graphviz (`sudo apt-get install graphviz`).


Agora estou com pouquissimo tempo para ajudar a aprimorar mais o pipeline, mas com certeza ainda tem muito para fazer. 

Os testes eu fiz no Ubuntu, no servidor do lab... ainda vou testar ele também na minha máquina que é um Mac!




