### PR TITLE
centralize sample and reference genome configuration

### DIFF
--- a/nextflow/config/nextflow.config
+++ b/nextflow/config/nextflow.config
@@ -3,6 +3,8 @@
 params {
     outdir = '../results'           // outside 'workflows' directory, e.g. 'nextflow/results' and not the projectDir 'nextflow/workflows/results' (ofc we can discuss other options)
     publish_dir_mode = 'symlink'    // avoid duplicating output files (I think we should always try to use symlink instead of copy mode)
+    samples_csv = "$projectDir/../samples/samples.csv"
+    ref_genome = "$projectDir/../references/cds_from_genomic.fna"
 }
 
 // OBS: that is just a draft version; we must try to remove every 'code smell' from our code (if possible)

--- a/nextflow/modules/salmonIndex.nf
+++ b/nextflow/modules/salmonIndex.nf
@@ -6,9 +6,6 @@ process salmonIndex {
         path "salmon_index", emit: index_dir
 
     script:
-        if (!file(reference_genome).exists()) {
-            error "ERRO: Genoma de referência não encontrado em: ${reference_genome}"
-        }
         """
         salmon index -t $reference_genome -i salmon_index
         """

--- a/nextflow/samples/samples.csv
+++ b/nextflow/samples/samples.csv
@@ -1,2 +1,2 @@
 run,sample_name
-SRR26130076,Chalmydomonas reinhardtii CC-1690_21gr transcriptomics
+ERR10671820,RNA-seq of Pseudomonas putida KT2440 and the derived strain P. putida pig21 treated with 1-octanol and PQS


### PR DESCRIPTION
this PR updates the workflow by moving sample and reference genome definitions entirely to the `nextflow.config file`.  

I also removed the error handling from `salmonQuant.nf`. I think its better to just let nextflow manage missing file errors natively.   