### PR TITLE
refactor: standardize module syntax 

### DIFF
--- a/modules/buildNetwork.nf
+++ b/modules/buildNetwork.nf
@@ -6,7 +6,6 @@ process buildNetwork {
         path("network.tsv") 
 
     script:
-        
         """
         echo "Generating network from expression matrix"
         ${projectDir}/../bin/generate_correlations_corals.py --expression_matrix $expression_matrix --output_network network.tsv

--- a/modules/downloadReadFTP.nf
+++ b/modules/downloadReadFTP.nf
@@ -5,8 +5,8 @@ process downloadReadFTP {
     output:
         tuple val(run), path("*.fastq.gz")
 
-    """
-    ${projectDir}/../bin/download_from_json.py --json ${json_file}
-    """
+    script:
+        """
+        ${projectDir}/../bin/download_from_json.py --json ${json_file}
+        """
 }
-

--- a/modules/getReadFTP.nf
+++ b/modules/getReadFTP.nf
@@ -1,14 +1,14 @@
 process getReadFTP {
+    maxForks 1  // limit parallel downloads: https://github.com/nextflow-io/nextflow/discussions/3415
+    
     input:
         val(run)
 
     output:
         tuple val(run), path("${run}.json")
 
-    maxForks 1  // limit parallel downloads: https://github.com/nextflow-io/nextflow/discussions/3415
-
-    """
-    ffq -o ${run}.json ${run}
-    """
+    script:
+        """
+        ffq -o ${run}.json ${run}
+        """
 }
-

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -5,8 +5,8 @@ process multiqc {
     output:
         path("multiqc_report.html")
 
-    """
-    multiqc ${fastqc_dirs.join(' ')}
-    """
+    script:
+        """
+        multiqc ${fastqc_dirs.join(' ')}
+        """
 }
-

--- a/modules/salmonQuantMerge.nf
+++ b/modules/salmonQuantMerge.nf
@@ -14,4 +14,3 @@ process salmonQuantMerge {
             --column TPM
         """
 }
-

--- a/modules/sampleInfo.nf
+++ b/modules/sampleInfo.nf
@@ -4,9 +4,9 @@ process sampleInfo {
 
     output:
         tuple val(run), file('*')
-
-    """
-    ${projectDir}/../bin/sampleinfo.sh ${json_file}
-    """
+    
+    script:
+        """
+        ${projectDir}/../bin/sampleinfo.sh ${json_file}
+        """
 }
-


### PR DESCRIPTION
minor refactor to standardize the code style and structure of all modules (we are always including `input`, `output` and `script` blocks).