### PR TITLE
Corrigindo problemas ao executar o workflow em um servidor HPC

### DIFF
--- a/config/nextflow.config
+++ b/config/nextflow.config
@@ -5,7 +5,7 @@ params {
     report_dir = 'report'
     publish_dir_mode = 'symlink'    // avoid duplicating output files (I think we should always try to use symlink instead of copy mode)
     samples_csv = "$projectDir/../samples/samples.csv"
-    ref_genome = "$projectDir/../references/cds_from_genomic.fna"
+    ref_genome = "$projectDir/../references/mrna_genomic_sequence.fna"   // adicionar as sequencias genomicas dos mRNAs anotados
 }
 
 // OBS: that is just a draft version; we must try to remove every 'code smell' from our code (if possible)

--- a/modules/downloadReadFTP.nf
+++ b/modules/downloadReadFTP.nf
@@ -1,4 +1,6 @@
 process downloadReadFTP {
+    maxForks 2  // limit parallel downloads: https://github.com/nextflow-io/nextflow/discussions/3415
+
     input:
         tuple val(run), path(json_file)
 


### PR DESCRIPTION
Ao testar, retornava um erro de conexão recusada do FTP, por conta da tentativa de download em paralelo. Além disso, o nome de arquivo de exemplo para a variavel "ref_genome" deixava o usuário em dúvida sobre qual tipo de dado é utilizado como entrada.

Arquivos modificados:
- config/nexflow.config: alterando o nome do arquivo esperado para "ref_genome"
- modules/downloadReadFTP.nf: adicionando o parâmetro "maxForks", limitando o número de conexões simultâneas para download dos dados.